### PR TITLE
Retry ls-remote call on failure

### DIFF
--- a/src/rosdistro/freeze_source.py
+++ b/src/rosdistro/freeze_source.py
@@ -83,7 +83,7 @@ def freeze_distribution_sources(dist, release_version=False, release_tag=False,
 
 
 # Get the repo commit information
-def _getRepoInfo(source_repo):
+def _get_repo_info(source_repo):
     count = 0
     # allow for a retry if the ls-remote fails to query the endpoint repo
     while True:
@@ -103,7 +103,7 @@ def _worker(work_queue):
     while True:
         try:
             source_repo, freeze_version, freeze_to_tag = work_queue.get(block=False)
-            ls_remote_lines = _getRepoInfo(source_repo)
+            ls_remote_lines = _get_repo_info(source_repo)
             for line in ls_remote_lines:
                 hash, ref = line.split('\t', 1)
                 if freeze_to_tag and ref == 'refs/tags/%s' % freeze_version:

--- a/src/rosdistro/freeze_source.py
+++ b/src/rosdistro/freeze_source.py
@@ -97,6 +97,8 @@ def _get_repo_info(source_repo):
             # reraise the error if we've attempted 3 times
             if count > 3:
                 raise
+            # brief delay incase its an intermittent issue with infrastructure
+            time.sleep(1)
 
 
 def _worker(work_queue):


### PR DESCRIPTION
Retry the git ls-remote call if it fails the first time.

Intermittent issues seen with ls-remote calls cause the version not to be frozen